### PR TITLE
Avoid exiting the sandbox process due to parsing errors

### DIFF
--- a/src/sandboxed_python/finite_python.py
+++ b/src/sandboxed_python/finite_python.py
@@ -586,7 +586,11 @@ class PySandbox(abc.ABC):
 
 def parse_fpy(source: str, filename: str | None = None) -> list[Stmt]:
     parser = _FPyParser(source, filename)
-    return parser._parse()
+    try:
+        result = parser._parse()
+    except (UnicodeEncodeError, MemoryError, RecursionError):
+        result = []
+    return result
 
 
 class _FPyParser:

--- a/src/sandboxed_python/tests/test_core.py
+++ b/src/sandboxed_python/tests/test_core.py
@@ -634,6 +634,18 @@ class TestHighLevel(unittest.TestCase):
                     with self.assertRaises(FPyException):
                         execute_fpy(source)
 
+    def test_catch_recursionerror(self):
+        source = "-" * 1000 + "1"
+        execute_fpy(source)
+
+    def test_catch_memoryerror(self):
+        source = "-" * 10000 + "1"
+        execute_fpy(source)
+
+    def test_catch_unicodeencodeerror(self):
+        source = "'\udbff\udfff'"
+        execute_fpy(source)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Parsing Python code may fail due to `MemoryError`, `RecursionError` or `UnicodeEncodeError`. This PR adds a guard against these exceptions. I don't know whether we should raise an exception when these errors are caught or just silently ignore them, as this PR does.

Fixes #1.